### PR TITLE
Remove service flags callout step from Deployment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-foxtrot.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-foxtrot.md
@@ -55,7 +55,7 @@
 
 ### Deployment 
 
-<!-- Any deployment considerations for this PR, including new service flags, dependencies, necessary order of operations etc. -->
+<!-- Any deployment considerations for this PR, including dependencies, necessary order of operations, etc. -->
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
@@ -37,7 +37,7 @@
 
 ### Deployment 
 
-<!-- Any deployment considerations for this PR, including new service flags, dependencies, necessary order of operations etc. -->
+<!-- Any deployment considerations for this PR, including dependencies, necessary order of operations, etc. -->
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,7 +37,7 @@
 
 ### Deployment 
 
-<!-- Any deployment considerations for this PR, including new service flags, dependencies, necessary order of operations etc. -->
+<!-- Any deployment considerations for this PR, including dependencies, necessary order of operations, etc. -->
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 


### PR DESCRIPTION
Since Helm chart flag values now live in service repos, changes should be part of the PR itself and don't need a note in the PR description. I added an item to [Before Creating A Pull Request](https://bookstack.niche.team/books/onboarding/page/pull-request-checklist) instead ("Any new or updated CLI parameters that need to have non-default values in production have been updated in `/charts/<service>/values.yaml`").