### PR TITLE
Broaden Foxtrot template to all Systems Intelligence

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
@@ -45,7 +45,8 @@
     - [ ] AC2
     - [ ] ...
 - [ ] Pull Request is linked to Asana task
-- [ ] CR has been offered to any other teams who the changes might effect
+- [ ] Other teams who might be affected by the changes have been notified and
+  offered a chance to CR
 - [ ] All appropriate automated Github checks pass
 - [ ] All the relevant `api-proctor` suites pass
 - [ ] Any new features requiring automation coverage are either

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
@@ -45,12 +45,12 @@
     - [ ] AC2
     - [ ] ...
 - [ ] Pull Request is linked to Asana task
+- [ ] CR has been offered to any other teams who the changes might effect
 - [ ] All appropriate automated Github checks pass
 - [ ] All the relevant `api-proctor` suites pass
 - [ ] Any new features requiring automation coverage are either
   - [ ] covered in an `api-proctor` PR here:
-  - [ ] documented on the
-  [PDO/ESO Automation Backlog](https://app.asana.com/0/1202082245735211/list).
+  - [ ] documented on the [SEIT Backlog](https://app.asana.com/0/1202082245735211/list).
 - [ ] There are no oustanding merge conflicts with dev
 
 ### Deployment 


### PR DESCRIPTION
Team Indigo would like to use the Team Foxtrot PR template, so this PR broadens the existing Foxtrot template to all of Systems Intelligence.

It also adds a QA checklist bullet point to consider offering CR to other teams that the changes might effect, as documented in [Notes - Foxtrot/Indigo: Technical Collaboration](https://docs.google.com/document/d/1svs3XQp2skS9AizZ_uqsVIGdUI9piOm8rZbkVspEhwU) as an action item.