### PR TITLE
Adds a reminder to update the BE Code Owners spreadsheet

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/README.md
+++ b/.github/PULL_REQUEST_TEMPLATE/README.md
@@ -1,10 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [Reminder](#reminder)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 ### Reminder
 
 These templates are publicly visible on the `nicheinc/.github` repository. Be

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
@@ -67,7 +67,7 @@
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 
-<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the [BE Code Owners spreadsheet](https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0/edit#gid=0). -->
+<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the BE Code Owners spreadsheet: https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0 -->
 
 <!-- If assistance is required from infrastructure (e.g. deploying a new service) consider making a request using this form: https://form.asana.com/?k=xVoCwpuX5uzj4Au4ALc0Yw&d=684757491145461 -->
 

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
@@ -67,6 +67,8 @@
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 
+<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the [BE Code Owners spreadsheet](https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0/edit#gid=0). -->
+
 <!-- If assistance is required from infrastructure (e.g. deploying a new service) consider making a request using this form: https://form.asana.com/?k=xVoCwpuX5uzj4Au4ALc0Yw&d=684757491145461 -->
 
 ### Versioning

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
@@ -45,6 +45,8 @@
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 
+<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the [BE Code Owners spreadsheet](https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0/edit#gid=0). -->
+
 <!-- If assistance is required from infrastructure (e.g. deploying a new service) consider making a request using this form: https://form.asana.com/?k=xVoCwpuX5uzj4Au4ALc0Yw&d=684757491145461 -->
 
 ### Versioning

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
@@ -45,7 +45,7 @@
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 
-<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the [BE Code Owners spreadsheet](https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0/edit#gid=0). -->
+<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the BE Code Owners spreadsheet: https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0 -->
 
 <!-- If assistance is required from infrastructure (e.g. deploying a new service) consider making a request using this form: https://form.asana.com/?k=xVoCwpuX5uzj4Au4ALc0Yw&d=684757491145461 -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,6 +45,8 @@
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 
+<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the [BE Code Owners spreadsheet](https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0/edit#gid=0). -->
+
 <!-- If assistance is required from infrastructure (e.g. deploying a new service) consider making a request using this form: https://form.asana.com/?k=xVoCwpuX5uzj4Au4ALc0Yw&d=684757491145461 -->
 
 ### Versioning

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@
 
 <!-- Does this PR represent a new back-end component that has never been deployed before? Consult the Production Readiness Checklist: https://docs.google.com/document/d/1MUjrz0m-zbTc4wmvxdmbCm6B2ML8fAluU7u9CqLSG9g/edit -->
 
-<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the [BE Code Owners spreadsheet](https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0/edit#gid=0). -->
+<!-- Does this PR update the Go, pgsql, or kafkalib versions? Does it add CI, an OpenAPI schema, or metrics? If so, make sure to update the BE Code Owners spreadsheet: https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0 -->
 
 <!-- If assistance is required from infrastructure (e.g. deploying a new service) consider making a request using this form: https://form.asana.com/?k=xVoCwpuX5uzj4Au4ALc0Yw&d=684757491145461 -->
 


### PR DESCRIPTION
### Description

I have a strong feeling that a lot of backenders (including myself) have been forgetting to maintain the [BE Code Owners spreadsheet](https://docs.google.com/spreadsheets/d/1q-BL9Ak0JVH9OwOa_q8vzQ2RzleVr2znk48f_rNh0v0/edit#gid=0). I recall a BENG topic where we collectively decided that this would be the "golden truth" for our service report cards. This PR adds a reminder to the PR template to update that spreadsheet. Linking the spreadsheet within a public repo shouldn't be an issue since the sheet is locked down to only Niche gmail accounts.

I'm open to changing the verbiage if whoever reviews this has a better idea.

(Also, we recently decided that we weren't going to use doctoc anymore so I removed the not-so-useful-anyway table of contents.)

### Deployment

🤠 
