### PR TITLE
Recommend Data Engineering Request Form over tagging GH group, and remove comment about the "NO QA" label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/README.md
+++ b/.github/PULL_REQUEST_TEMPLATE/README.md
@@ -1,10 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [Reminder](#reminder)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 ### Reminder
 
 These templates are publicly visible on the `nicheinc/.github` repository. Be

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
@@ -23,8 +23,6 @@
 
 <!-- Any specific testing considerations for this PR: dependencies, sample UUIDs, test data etc. -->
 
-<!-- If this PR will not be tested by a QE, remember to add the "NO QA" label. -->
-
 ### SQL Migrations
 
 <!-- Does this PR add PII to a new table? Consult Data Privacy Compliance: https://bookstack.niche.team/books/back-end-patterns-practices/page/data-privacy-compliance -->

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template-systems-intelligence.md
@@ -27,16 +27,15 @@
 
 <!-- Does this PR add PII to a new table? Consult Data Privacy Compliance: https://bookstack.niche.team/books/back-end-patterns-practices/page/data-privacy-compliance -->
 
-<!-- Uncomment and fill in this section if both of the following are true:
+<!-- If both of the following are true...
 
   1. This PR adds a new table or a new column with a default value
   2. Your team or another team needs these schema changes to be reflected in Snowflake
 
-Migration script: <link to migration script file>
-
-Description: <a description of the schema changes made by this migration script>
-
-Notice for the Data Engineering team: @nicheinc/data-engineering
+...then submit a Data Engineering Request Form
+(https://nicheinc.atlassian.net/servicedesk/customer/portal/5) asking for your
+schema changes be reflected in Snowflake. Be sure to include a link to your PR
+and schema migration files, along with a description of the schema changes.
 -->
 
 ### QA Handoff Checklist

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
@@ -23,8 +23,6 @@
 
 <!-- Any specific testing considerations for this PR: dependencies, sample UUIDs, test data etc. -->
 
-<!-- If this PR will not be tested by a QE, remember to add the "NO QA" label. -->
-
 ### SQL Migrations
 
 <!-- Does this PR add PII to a new table? Consult Data Privacy Compliance: https://bookstack.niche.team/books/back-end-patterns-practices/page/data-privacy-compliance -->

--- a/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/back-end-pr-template.md
@@ -27,16 +27,15 @@
 
 <!-- Does this PR add PII to a new table? Consult Data Privacy Compliance: https://bookstack.niche.team/books/back-end-patterns-practices/page/data-privacy-compliance -->
 
-<!-- Uncomment and fill in this section if both of the following are true:
+<!-- If both of the following are true...
 
   1. This PR adds a new table or a new column with a default value
   2. Your team or another team needs these schema changes to be reflected in Snowflake
 
-Migration script: <link to migration script file>
-
-Description: <a description of the schema changes made by this migration script>
-
-Notice for the Data Engineering team: @nicheinc/data-engineering
+...then submit a Data Engineering Request Form
+(https://nicheinc.atlassian.net/servicedesk/customer/portal/5) asking for your
+schema changes be reflected in Snowflake. Be sure to include a link to your PR
+and schema migration files, along with a description of the schema changes.
 -->
 
 ### Deployment

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,8 +23,6 @@
 
 <!-- Any specific testing considerations for this PR: dependencies, sample UUIDs, test data etc. -->
 
-<!-- If this PR will not be tested by a QE, remember to add the "NO QA" label. -->
-
 ### SQL Migrations
 
 <!-- Does this PR add PII to a new table? Consult Data Privacy Compliance: https://bookstack.niche.team/books/back-end-patterns-practices/page/data-privacy-compliance -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,16 +27,15 @@
 
 <!-- Does this PR add PII to a new table? Consult Data Privacy Compliance: https://bookstack.niche.team/books/back-end-patterns-practices/page/data-privacy-compliance -->
 
-<!-- Uncomment and fill in this section if both of the following are true:
+<!-- If both of the following are true...
 
   1. This PR adds a new table or a new column with a default value
   2. Your team or another team needs these schema changes to be reflected in Snowflake
 
-Migration script: <link to migration script file>
-
-Description: <a description of the schema changes made by this migration script>
-
-Notice for the Data Engineering team: @nicheinc/data-engineering
+...then submit a Data Engineering Request Form
+(https://nicheinc.atlassian.net/servicedesk/customer/portal/5) asking for your
+schema changes be reflected in Snowflake. Be sure to include a link to your PR
+and schema migration files, along with a description of the schema changes.
 -->
 
 ### Deployment


### PR DESCRIPTION
### Documentation

- [Thread re: Data Engineering Request Form](https://nicheinc.slack.com/archives/C0GN6575G/p1759443954946129?thread_ts=1754925085.706009&cid=C0GN6575G)
- [Thread re: NO QA](https://nicheinc.slack.com/archives/C01M7JTG4JJ/p1759500449689259)

### Description

This updates the Core PR templates to recommend submitting a Data Engineering Request Form rather than tagging `@nicheinc/data-engineering`.

I have also removed the instructions to add the "NO QA" label on PRs without full QA since people aren't using that consistently anyway, and we're not planning to report on that label in `deploy-stats`.